### PR TITLE
Update data_storage.js - disarm_kill_switch default

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -260,11 +260,12 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         if(CONFIG.apiVersion >= 1.8) {
             $('input[name="autodisarmdelay"]').val(ARMING_CONFIG.auto_disarm_delay);
             $('input[name="disarmkillswitch"]').prop('checked', ARMING_CONFIG.disarm_kill_switch);
-            if(bit_check(BF_CONFIG.features, 4 + 1))//MOTOR_STOP
+            $('div.disarm').show();            
+            if(bit_check(BF_CONFIG.features, 4))//MOTOR_STOP
                 $('div.disarmdelay').show();
+            else
+                $('div.disarmdelay').hide();
         }
-        else       
-            $('div.disarm').hide();
         
         // fill throttle
         $('input[name="minthrottle"]').val(MISC.minthrottle);

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -9,6 +9,8 @@ TABS.led_strip = {
 TABS.led_strip.initialize = function (callback, scrollPosition) {
     var self = this;
 
+    TABS.led_strip.wireMode = false;
+
     if (GUI.active_tab != 'led_strip') {
         GUI.active_tab = 'led_strip';
         googleAnalytics.sendAppView('LED Strip');
@@ -153,8 +155,8 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         });
 
         $('.funcWire').click(function() {
-            (TABS.led_strip.wireMode) ? TABS.led_strip.wireMode=false : TABS.led_strip.wireMode=true;
             $(this).toggleClass('btnOn');
+            TABS.led_strip.wireMode = $(this).hasClass('btnOn'); 
             $('.mainGrid').toggleClass('gridWire');
         });
 

--- a/tabs/sensors.html
+++ b/tabs/sensors.html
@@ -197,7 +197,7 @@
     </div>
     <div class="wrapper debug">
         <div class="plot_control">
-            <div class="title">Debug 1</div>
+            <div class="title">Debug 0</div>
             <dl>
                 <dt i18n="sensorsRefresh"></dt>
                 <dd class="rate">
@@ -225,7 +225,7 @@
         </svg>
         <div class="clear-both"></div>
         <div class="plot_control">
-            <div class="title">Debug 2</div>
+            <div class="title">Debug 1</div>
             <dl>
                 <dt>X:</dt><dd class="x">blue</dd>
             </dl>
@@ -239,7 +239,7 @@
         </svg>
         <div class="clear-both"></div>
         <div class="plot_control">
-            <div class="title">Debug 3</div>
+            <div class="title">Debug 2</div>
             <dl>
                 <dt>X:</dt><dd class="x">0</dd>
             </dl>
@@ -253,7 +253,7 @@
         </svg>
         <div class="clear-both"></div>
         <div class="plot_control">
-            <div class="title">Debug 4</div>
+            <div class="title">Debug 3</div>
             <dl>
                 <dt>X:</dt><dd class="x">0</dd>
             </dl>


### PR DESCRIPTION
Bug fix - disarm_kill_switch default must be 1.
As per the docs - Setting to 0 reverts to the old behaviour of disarming only when the throttle is low. Only applies when arming and disarming with an AUX channel.
